### PR TITLE
Fixed problem with "Enter Negative Prompt" checkbox being checked after UI is loaded

### DIFF
--- a/javascript/easy_prompt_selector.js
+++ b/javascript/easy_prompt_selector.js
@@ -96,6 +96,7 @@ class EPSElementBuilder {
     label.style.alignItems = 'center'
 
     const checkbox = gradioApp().querySelector('input[type=checkbox]').cloneNode()
+    checkbox.checked = false
     checkbox.addEventListener('change', (event) => {
        onChange(event.target.checked)
     })


### PR DESCRIPTION
特定の条件で、UIのロード後に「ネガティブプロンプトに入力」のチェックボックスにチェックが入ってしまう問題に気づいたので修正してみました。

## 再現手順

1. `Settings -> User Interface` の `Quicksettings list` に、チェックボックスが追加されるような設定を追加する（例： `upcast_attn` ）。
2. UIをリロードすると、画面上部にチェックボックスが追加されるので、チェックを入れてから再度UIをリロードする。
![image](https://user-images.githubusercontent.com/132233681/236609437-e07ae79c-214d-4719-83d0-69a3018401d3.png)
3. 「タグを選択」ボタンを押してEasy Prompt SelectorのUIを表示させる。
4. 「ネガティブプロンプトに入力」にチェックが入った状態で表示されてしまう。
![image](https://user-images.githubusercontent.com/132233681/236609525-65f605a0-a821-45ce-98cd-23faf91dd28a.png)

大した不具合ではないですが、何かの際に取り込んでいただけると嬉しいです。よろしくお願いします。

