### PR TITLE
Fixed problem when YAML file name contains multiple periods

### DIFF
--- a/javascript/easy_prompt_selector.js
+++ b/javascript/easy_prompt_selector.js
@@ -156,7 +156,7 @@ class EasyPromptSelector {
 
     const tags = {}
     for (const path of paths) {
-      const filename = path.split('/').pop().split('.').shift()
+      const filename = path.split('/').pop().split('.').slice(0, -1).join('.')
       const data = await this.readFile(path)
       yaml.loadAll(data, function (doc) {
         tags[filename] = doc


### PR DESCRIPTION
YAMLファイルの名前に複数のピリオドが含まれていた場合の問題を修正しました。