### PR TITLE
Added the ability to display images related to tags

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,3 +8,15 @@
 .easy_prompt_selector_button {
   flex: 1;
 }
+
+span.easy_prompt_selector_tag img {
+    display: none;
+}
+
+span.easy_prompt_selector_tag:hover img {
+    display: inline-block;
+    position: absolute;
+    margin-left: 1rem;
+    max-width: 480px;
+    z-index: 100;
+}


### PR DESCRIPTION
例えば https://note.com/aine_miyabi/n/n4dbadbcb882b のymlを使う時、タグの意味を視覚的に確認できると分かりやすいなと思い、タグにマウスカーソルを乗せると（あれば）画像が表示される機能を追加しました。

イメージ：
https://github.com/blue-pen5805/sdweb-easy-prompt-selector/assets/132233681/60d69887-8bc7-4063-88b8-0842abd5d618

もし取り込んでいただける場合、お好きなように改変していただいて構いません。よろしくお願いします。

### 使い方

yamlファイルがある場所に、yamlファイルと同じ名前のフォルダを作成して中にタグ名と同じ名前で画像を置いてください。yamlファイルの中に階層がある場合はその階層でフォルダを作成してください。

例：

`構図.yml`
```
構図:
  上から: from above
  下から: from below
  横から: from side
  後から: from behine
  真上から: overhead shot
  顔アップ: close up
```

ファイルツリー
```
.
├── 構図
│   └── 構図
│       ├── 上から.png
│       ├── 下から.png
│       ├── 後から.png
│       ├── 横から.png
│       ├── 真上から.png
│       └── 顔アップ.png
└── 構図.yml
```

画像の拡張子はデフォルトは `.jpg` ですが、yamlファイルに `.settings` を追加して記載することで他の拡張子を使うこともできます。

例：
```
.settings:
  fileFormatForImages: png
構図:
  上から: from above
  下から: from below
  横から: from side
  後から: from behine
  真上から: overhead shot
  顔アップ: close up
```



