### PR TITLE
Add adjective prompt support

### DIFF
--- a/javascript/easy_prompt_selector.js
+++ b/javascript/easy_prompt_selector.js
@@ -246,8 +246,8 @@ class EasyPromptSelector {
 
         if (typeof values === 'string') { 
           return this.renderTagButton(
-            key, 
             values.trim().endsWith('*') ? key + ':' : key, 
+            values,
             'secondary'
           ) 
         }

--- a/javascript/easy_prompt_selector.js
+++ b/javascript/easy_prompt_selector.js
@@ -125,6 +125,7 @@ class EasyPromptSelector {
     this.visible = false
     this.toNegative = false
     this.tags = undefined
+    this.adjectiveLast = false
   }
 
   async init() {
@@ -243,7 +244,13 @@ class EasyPromptSelector {
         const values = tags[key]
         const randomKey = `${prefix}:${key}`
 
-        if (typeof values === 'string') { return this.renderTagButton(key, values, 'secondary') }
+        if (typeof values === 'string') { 
+          return this.renderTagButton(
+            key, 
+            values.trim().endsWith('*') ? key + ':' : key, 
+            'secondary'
+          ) 
+        }
 
         const fields = EPSElementBuilder.tagFields()
         fields.style.flexDirection = 'column'
@@ -287,15 +294,19 @@ class EasyPromptSelector {
   addTag(tag, toNegative = false) {
     const id = toNegative ? 'txt2img_neg_prompt' : 'txt2img_prompt'
     const textarea = gradioApp().getElementById(id).querySelector('textarea')
+    const tagToAdd = tag.trim().replace(/\*$/, '')
 
     if (textarea.value.trim() === '') {
-      textarea.value = tag
+      textarea.value = tagToAdd
+    } else if (this.adjectiveLast) {
+      textarea.value += ' ' + tagToAdd
     } else if (textarea.value.trim().endsWith(',')) {
-      textarea.value += ' ' + tag
+      textarea.value += ' ' + tagToAdd
     } else {
-      textarea.value += ', ' + tag
+      textarea.value += ', ' + tagToAdd
     }
 
+    this.adjectiveLast = tag.trim().endsWith('*')
     updateInput(textarea)
   }
 


### PR DESCRIPTION
Add adjective prompt word support, now may use trailing `*` mark adjective prompt. When adding an adjective prompt, textarea won't add trailing comma, and will wait to add next prompt.

For example, the tag file is defined as below.

```yaml
Patterns:
    Checkered: checkered *
    Grid: grid *
    Paw Printed: paw printed *

Entity:
    - background
```

Those `Patterns` will show on UI as `Checkered:`, `Grid:`, etc. Trailing `:` prompts this prompt is a adjective prompt. Click **adjective** prompt and then click other __entity__ prompt, will add prompt to textarea like `grid background`, but not `gird, background` as before.

And so as random prompt function. For example, `@2$$theme:Patterns@ background, 1other` will be expanded to `grid background, checkered background, 1other`.