### PR TITLE
remove `style()` method

### DIFF
--- a/scripts/easy_prompt_selector.py
+++ b/scripts/easy_prompt_selector.py
@@ -93,8 +93,7 @@ class Script(scripts.Script):
         if (is_img2img):
             return None
 
-        reload_button = gr.Button('🔄', variant='secondary', elem_id='easy_prompt_selector_reload_button')
-        reload_button.style(size='sm')
+        reload_button = gr.Button('🔄', variant='secondary', size="sm", elem_id='easy_prompt_selector_reload_button')
 
         def reload():
             self.tags = load_tags()


### PR DESCRIPTION
`Button` クラスの `style()` メソッドの利用が非推奨となっており、webui の起動時に以下の警告が表示されていました。
```log
path/to/easy_prompt_selector.py:97: GradioDeprecationWarning: The `style` method is deprecated. Please set these arguments in the constructor instead.
  reload_button.style(size='sm')
```

メッセージでの指摘の通り、`style()` メソッドは削除し、`Button` のコンストラクタで `size` プロパティの指定するように変更しました。
お手数ですが、もし問題が無ければマージして頂ければと思います。
以上、よろしくお願いいたします。